### PR TITLE
Correct the baseurl to generate the feed correctly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,8 @@ title: openSUSE MicroOS
 title_short: MicroOS
 email: opensuse-factory@opensuse.org
 description: Micro Service OS built by the openSUSE community
-copyright: '© 2017–2021 openSUSE contributors'
-baseurl: ""
-url: ""
+copyright: '© 2017–2023 openSUSE contributors'
+baseurl: "https://microos.opensuse.org"
 plugins:
   - jekyll-feed
   - jekyll-paginate


### PR DESCRIPTION
Right now the url in the feed doesn't include the baseurl because it doesn't know what it is. This could also be corrected in the build script with `--baseurl https://microos.opensuse.org` at the end of `jekyll build` command, but this is the only solution I have access to :P 